### PR TITLE
New: Add support for Tooltip API and Navigation Button API (fixes #16 #23)

### DIFF
--- a/example.json
+++ b/example.json
@@ -17,7 +17,6 @@
     }
 }
 
-
 // course.json
 "_homeButton": {
     "_isEnabled": true,

--- a/example.json
+++ b/example.json
@@ -9,6 +9,7 @@
 "_extensions": {
     "_homeButton": {
         "_navOrder": 1,
+        "alt": "Home",
         "_showLabel": true,
         "navLabel": "Home",
         "_navTooltip": {
@@ -18,7 +19,7 @@
     }
 }
 
-// course.json - Use to configure at the menu level
+// course.json or contentObjects - Use to configure at the menu or content object level
 "_homeButton": {
     "_isEnabled": true,
     "_hideHomeButton": false,
@@ -30,20 +31,5 @@
     "_navTooltip": {
         "_isEnabled": true,
         "text": "Introduction"
-    }
-}
-
-// contentObjects.json - Use to configure at the content object level
-"_homeButton": {
-    "_isEnabled": true,
-    "_hideHomeButton": false,
-    "_hideBackButton": true,
-    "_redirectToId": "",
-    "alt": "Home",
-    "_comment": "Option to override navigation button label and tooltip",
-    "navLabel": "Home",
-    "_navTooltip": {
-        "_isEnabled": true,
-        "text": "Home"
     }
 }

--- a/example.json
+++ b/example.json
@@ -2,34 +2,32 @@
 
 // config.json - Used to disable globally
 "_homeButton": {
-    "_isEnabled": false
+  "_isEnabled": false
 }
 
 // course.json - Use for global settings and navigation order
 "_extensions": {
-    "_homeButton": {
-        "_navOrder": 1,
-        "alt": "Home",
-        "_showLabel": true,
-        "navLabel": "Home",
-        "_navTooltip": {
-            "_isEnabled": false,
-            "text": "Home"
-        }
+  "_homeButton": {
+    "_navOrder": -1,
+    "_showLabel": true,
+    "navLabel": "Home",
+    "_navTooltip": {
+      "_isEnabled": false,
+      "text": "Home"
     }
+  }
 }
 
 // course.json or contentObjects - Use to configure at the menu or content object level
 "_homeButton": {
+  "_isEnabled": true,
+  "_hideHomeButton": false,
+  "_comment": "Amend _redirectToId to match the ID of the start / landing page",
+  "_redirectToId": "",
+  "_comment": "Option to override navigation button label and tooltip",
+  "navLabel": "Introduction",
+  "_navTooltip": {
     "_isEnabled": true,
-    "_hideHomeButton": false,
-    "_comment": "Amend _redirectToId to match the ID of the start / landing page",
-    "_redirectToId": "co-00",
-    "alt": "Introduction",
-    "_comment": "Option to override navigation button label and tooltip",
-    "navLabel": "Introduction",
-    "_navTooltip": {
-        "_isEnabled": true,
-        "text": "Introduction"
-    }
+    "text": "Introduction"
+  }
 }

--- a/example.json
+++ b/example.json
@@ -1,14 +1,15 @@
 // Configuration options must be added and amended for all JSON files where required
 
-// config.json - to disable globally
+// config.json - Used to disable globally
 "_homeButton": {
     "_isEnabled": false
 }
 
-// course.json
+// course.json - Use for global settings and navigation order
 "_extensions": {
     "_homeButton": {
         "_navOrder": 1,
+        "_showLabel": true,
         "navLabel": "Home",
         "_navTooltip": {
             "_isEnabled": false,
@@ -17,20 +18,32 @@
     }
 }
 
-// course.json
+// course.json - Use to configure at the menu level
 "_homeButton": {
     "_isEnabled": true,
     "_hideHomeButton": false,
-    "_comment": "Amend co-00 to match the ID of the start / landing page",
+    "_comment": "Amend _redirectToId to match the ID of the start / landing page",
     "_redirectToId": "co-00",
-    "alt": "Introduction"
+    "alt": "Introduction",
+    "_comment": "Option to override navigation button label and tooltip",
+    "navLabel": "Introduction",
+    "_navTooltip": {
+        "_isEnabled": true,
+        "text": "Introduction"
+    }
 }
 
-// contentObjects.json
+// contentObjects.json - Use to configure at the content object level
 "_homeButton": {
     "_isEnabled": true,
     "_hideHomeButton": false,
     "_hideBackButton": true,
     "_redirectToId": "",
-    "alt": "Home"
+    "alt": "Home",
+    "_comment": "Option to override navigation button label and tooltip",
+    "navLabel": "Home",
+    "_navTooltip": {
+        "_isEnabled": true,
+        "text": "Home"
+    }
 }

--- a/example.json
+++ b/example.json
@@ -1,24 +1,37 @@
-    // Configuration options must be added and amended for all json files where required
+// Configuration options must be added and amended for all JSON files where required
 
-    // config.json - to disable globally
-    "_homeButton": {
-        "_isEnabled": false
-    }
+// config.json - to disable globally
+"_homeButton": {
+    "_isEnabled": false
+}
 
-    // course.json
+// course.json
+"_extensions": {
     "_homeButton": {
-        "_isEnabled": true,
-        "_hideHomeButton": false,
-        "_comment": "Amend co-00 to match the ID of the start / landing page",
-        "_redirectToId": "co-00",
-        "alt": "Introduction"
+        "_navOrder": 1,
+        "navLabel": "Home",
+        "_navTooltip": {
+            "_isEnabled": false,
+            "text": "Home"
+        }
     }
+}
 
-    // contentObjects.json
-    "_homeButton": {
-        "_isEnabled": true,
-        "_hideHomeButton": false,
-        "_hideBackButton": true,
-        "_redirectToId": "",
-        "alt": "Home"
-    }
+
+// course.json
+"_homeButton": {
+    "_isEnabled": true,
+    "_hideHomeButton": false,
+    "_comment": "Amend co-00 to match the ID of the start / landing page",
+    "_redirectToId": "co-00",
+    "alt": "Introduction"
+}
+
+// contentObjects.json
+"_homeButton": {
+    "_isEnabled": true,
+    "_hideHomeButton": false,
+    "_hideBackButton": true,
+    "_redirectToId": "",
+    "alt": "Home"
+}

--- a/js/HomeNavigationButtonView.js
+++ b/js/HomeNavigationButtonView.js
@@ -4,46 +4,31 @@ import tooltips from 'core/js/tooltips';
 
 class HomeNavigationButtonView extends NavigationButtonView {
 
+  attributes() {
+    const attributes = super.attributes();
+    return Object.assign(attributes, {
+      'data-tooltip-id': this.model.get('_id')
+    });
+  }
+
   initialize(options) {
     super.initialize(options);
-    this.setUpEventListeners();
+    this.setupEventListeners();
     this.render();
-
     tooltips.register({
-      _id: 'HomeButton',
+      _id: this.model.get('_id'),
       ...this.model.get('_navTooltip') || {}
     });
   }
 
-  static get globalsConfig() {
-    return Adapt.course.get('_globals')?._extensions?._homeButton;
-  }
-
-  static get template() {
-    return 'HomeNavigationButton.jsx';
-  }
-
-  attributes() {
-    const attributes = this.model.toJSON();
-
-    return {
-      name: attributes._id,
-      role: attributes._role === 'button' ? undefined : attributes._role,
-      'data-order': attributes._order,
-      'aria-label': attributes.alt,
-      'data-event': attributes._dataEvent,
-      'data-tooltip-id': 'HomeButton'
-    };
-  }
-
-  setUpEventListeners() {
+  setupEventListeners() {
     this.listenTo(Adapt, {
       remove: this.remove
     });
   }
 
-  remove() {
-    super.remove();
+  static get template() {
+    return 'HomeNavigationButton.jsx';
   }
 
 }

--- a/js/HomeNavigationButtonView.js
+++ b/js/HomeNavigationButtonView.js
@@ -1,0 +1,51 @@
+import Adapt from 'core/js/adapt';
+import NavigationButtonView from 'core/js/views/NavigationButtonView';
+import tooltips from 'core/js/tooltips';
+
+class HomeNavigationButtonView extends NavigationButtonView {
+
+  initialize(options) {
+    super.initialize(options);
+    this.render();
+
+    tooltips.register({
+      _id: 'HomeButton',
+      ...HomeNavigationButtonView.globalsConfig._navTooltip || {}
+    });
+  }
+
+  static get globalsConfig() {
+    return Adapt.course.get('_globals')?._extensions?._homeButton;
+  }
+
+  static get template() {
+    return 'HomeNavigationButton.jsx';
+  }
+
+  attributes() {
+    const attributes = this.model.toJSON();
+
+    return {
+      name: attributes._id,
+      role: attributes._role === 'button' ? undefined : attributes._role,
+      'data-order': attributes._order,
+      // 'aria-label': Adapt.course.get('_homeButton').navigationAriaLabel,
+      'aria-label': 'TBD',
+      'data-tooltip-id': 'HomeButton'
+    };
+  }
+
+  events() {
+    return {
+      click: 'onClick'
+    };
+  }
+
+  onClick(event) {
+    if (event && event.preventDefault) event.preventDefault();
+    // redirected()
+  }
+
+}
+
+export default HomeNavigationButtonView;

--- a/js/HomeNavigationButtonView.js
+++ b/js/HomeNavigationButtonView.js
@@ -30,7 +30,7 @@ class HomeNavigationButtonView extends NavigationButtonView {
       name: attributes._id,
       role: attributes._role === 'button' ? undefined : attributes._role,
       'data-order': attributes._order,
-      'aria-label': attributes.navigationAriaLabel,
+      'aria-label': attributes.alt,
       'data-event': attributes._dataEvent,
       'data-tooltip-id': 'HomeButton'
     };

--- a/js/HomeNavigationButtonView.js
+++ b/js/HomeNavigationButtonView.js
@@ -5,10 +5,10 @@ import tooltips from 'core/js/tooltips';
 class HomeNavigationButtonView extends NavigationButtonView {
 
   attributes() {
-    const attributes = super.attributes();
-    return Object.assign(attributes, {
+    return {
+      ...super.attributes(),
       'data-tooltip-id': this.model.get('_id')
-    });
+    };
   }
 
   initialize(options) {

--- a/js/HomeNavigationButtonView.js
+++ b/js/HomeNavigationButtonView.js
@@ -6,11 +6,14 @@ class HomeNavigationButtonView extends NavigationButtonView {
 
   initialize(options) {
     super.initialize(options);
+    this.setUpEventListeners();
     this.render();
+
+    const attributes = this.model.toJSON();
 
     tooltips.register({
       _id: 'HomeButton',
-      ...HomeNavigationButtonView.globalsConfig._navTooltip || {}
+      _navTooltip: attributes._navTooltip
     });
   }
 
@@ -29,21 +32,20 @@ class HomeNavigationButtonView extends NavigationButtonView {
       name: attributes._id,
       role: attributes._role === 'button' ? undefined : attributes._role,
       'data-order': attributes._order,
-      // 'aria-label': Adapt.course.get('_homeButton').navigationAriaLabel,
-      'aria-label': 'TBD',
+      'aria-label': attributes.navigationAriaLabel,
+      'data-event': attributes._dataEvent,
       'data-tooltip-id': 'HomeButton'
     };
   }
 
-  events() {
-    return {
-      click: 'onClick'
-    };
+  setUpEventListeners() {
+    this.listenTo(Adapt, {
+      remove: this.remove
+    });
   }
 
-  onClick(event) {
-    if (event && event.preventDefault) event.preventDefault();
-    // redirected()
+  remove() {
+    super.remove();
   }
 
 }

--- a/js/HomeNavigationButtonView.js
+++ b/js/HomeNavigationButtonView.js
@@ -9,11 +9,9 @@ class HomeNavigationButtonView extends NavigationButtonView {
     this.setUpEventListeners();
     this.render();
 
-    const attributes = this.model.toJSON();
-
     tooltips.register({
       _id: 'HomeButton',
-      _navTooltip: attributes._navTooltip
+      ...this.model.get('_navTooltip') || {}
     });
   }
 

--- a/js/adapt-homeButton.js
+++ b/js/adapt-homeButton.js
@@ -63,40 +63,23 @@ class HomeButton extends Backbone.Controller {
 
   renderNavigationView() {
     const currentModelConfig = this.currentModelConfig;
-
-    // Default to global config
-    let {
-      _navOrder = 0,
+    const {
+      _navOrder = -1,
       _showLabel = true,
-      alt = '',
       navLabel = '',
       _navTooltip = {}
-    } = HomeButton.globalsConfig ?? {};
-
-    // Check for overrides on current model
-    if (currentModelConfig.navLabel) {
-      navLabel = currentModelConfig.navLabel;
-    }
-    if (currentModelConfig._navTooltip && currentModelConfig._navTooltip.text) {
-      _navTooltip = currentModelConfig._navTooltip;
-    }
-    if (currentModelConfig.alt) {
-      alt = currentModelConfig.alt;
-    }
-
+    } = Object.assign(HomeButton.globalsConfig ?? {}, currentModelConfig);
     const model = new NavigationButtonModel({
-      _id: 'HomeButton',
+      _id: 'homebutton',
       _order: _navOrder,
       _showLabel,
       _classes: 'btn-icon nav__btn nav__homebutton-btn',
-      _iconClasses: '',
       _role: 'link',
+      ariaLabel: navLabel,
       text: navLabel,
       _navTooltip,
-      alt,
-      _dataEvent: currentModelConfig?._redirectToId ? 'redirectedHomeButton' : 'homeButton'
+      _event: currentModelConfig?._redirectToId ? 'redirectedHomeButton' : 'homeButton'
     });
-
     navigation.addButton(new HomeNavigationButtonView({ model }));
   }
 

--- a/js/adapt-homeButton.js
+++ b/js/adapt-homeButton.js
@@ -77,7 +77,7 @@ class HomeButton extends Backbone.Controller {
     if (currentModelConfig.navLabel) {
       navLabel = currentModelConfig.navLabel;
     }
-    if (currentModelConfig._navTooltip) {
+    if (currentModelConfig._navTooltip && currentModelConfig._navTooltip.text) {
       _navTooltip = currentModelConfig._navTooltip;
     }
     if (currentModelConfig.alt) {

--- a/js/adapt-homeButton.js
+++ b/js/adapt-homeButton.js
@@ -81,7 +81,7 @@ class HomeButton extends Backbone.Controller {
       _navTooltip = currentModelConfig._navTooltip;
     }
     if (currentModelConfig.alt) {
-      alt = currentModelConfig.navigationAriaLabel;
+      alt = currentModelConfig.alt;
     }
 
     const model = new NavigationButtonModel({

--- a/less/homeButton.less
+++ b/less/homeButton.less
@@ -1,20 +1,18 @@
-.nav {
-  // replicate navigation back button float
-  &__homebutton-btn {
-    .u-float-left;
-  }
+.nav__homebutton-btn {
+  // Replicate navigation back button float
+  .u-float-left;
 
-  // hide home button class
-  .hide-nav-home-btn &__homebutton-btn {
+  // Hide home button class
+  .hide-nav-home-btn & {
     .u-display-none;
   }
 
   // Change the home button icon to use the back arrow on the menu
-  .location-menu &__homebutton-btn .icon {
+  .location-menu & .icon {
     .icon-controls-small-left;
   }
 
-  .location-page &__homebutton-btn .icon {
+  .location-page & .icon {
     .icon-home;
   }
 }

--- a/less/homeButton.less
+++ b/less/homeButton.less
@@ -1,7 +1,4 @@
 .nav__homebutton-btn {
-  // Replicate navigation back button float
-  .u-float-left;
-
   // Hide home button class
   .hide-nav-home-btn & {
     .u-display-none;

--- a/properties.schema
+++ b/properties.schema
@@ -3,6 +3,52 @@
   "$schema": "http://json-schema.org/draft-04/schema",
   "id": "http://jsonschema.net",
   "required": false,
+  "globals": {
+    "_navOrder": {
+      "type": "number",
+      "required": true,
+      "title": "Navigation bar order",
+      "help": "Determines the order in which the button is displayed in the navigation bar. Negative numbers (e.g. -100) are left-aligned. Positive numbers (e.g. 100) are right-aligned.",
+      "default": 0,
+      "inputType": "Text",
+      "validators": []
+    },
+    "_showLabel": {
+      "type": "boolean",
+      "required": true,
+      "default": true,
+      "title": "Enable navigation bar button label",
+      "inputType": "Checkbox",
+      "validators": [],
+      "help": "Controls whether a label is shown on the navigation bar button."
+    },
+    "navLabel": {
+      "type": "string",
+      "required": true,
+      "default": "Home",
+      "title": "Navigation bar button label",
+      "inputType": "Text",
+      "validators": [],
+      "translatable": true
+    },
+    "_navTooltip": {
+      "type": "object",
+      "title": "Navigation tooltip",
+      "properties": {
+        "_isEnabled": {
+          "type": "boolean",
+          "title": "Enable tooltip for navigation button",
+          "default": true
+        },
+        "text": {
+          "type": "string",
+          "title": "",
+          "default": "Home",
+          "translatable": true
+        }
+      }
+    }
+  },
   "properties": {
     "pluginLocations": {
       "type": "object",

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -25,7 +25,7 @@
                       "type": "number",
                       "title": "Navigation bar order",
                       "description": "Determines the order in which the button is displayed in the navigation bar. Negative numbers (e.g. -100) are left-aligned. Positive numbers (e.g. 100) are right-aligned.",
-                      "default": 0
+                      "default": -1
                     },
                     "_showLabel": {
                       "type": "boolean",
@@ -85,14 +85,6 @@
               "title": "Redirect the home button to id",
               "description": "Enter the Friendly id of the page that the home button should direct the user to (ex. a splash page)",
               "default": ""
-            },
-            "alt": {
-              "type": "string",
-              "title": "Home button alt text - applied globally",
-              "default": "Home",
-              "_adapt": {
-                "translatable": true
-              }
             }
           }
         }

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -8,6 +8,63 @@
     },
     "with": {
       "properties": {
+        "_globals": {
+          "type": "object",
+          "default": {},
+          "properties": {
+            "_extensions": {
+              "type": "object",
+              "default": {},
+              "properties": {
+                "_homeButton": {
+                  "type": "object",
+                  "title": "Home Button",
+                  "default": {},
+                  "properties": {
+                    "_navOrder": {
+                      "type": "number",
+                      "title": "Navigation bar order",
+                      "description": "Determines the order in which the button is displayed in the navigation bar. Negative numbers (e.g. -100) are left-aligned. Positive numbers (e.g. 100) are right-aligned.",
+                      "default": 0
+                    },
+                    "_showLabel": {
+                      "type": "boolean",
+                      "title": "Enable navigation bar button label",
+                      "default": true
+                    },
+                    "navLabel": {
+                      "type": "string",
+                      "title": "Navigation bar button label",
+                      "default": "Home",
+                      "_adapt": {
+                        "translatable": true
+                      }
+                    },
+                    "_navTooltip": {
+                      "type": "object",
+                      "title": "Navigation tooltip",
+                      "properties": {
+                        "_isEnabled": {
+                          "type": "boolean",
+                          "title": "Enable tooltip for navigation button",
+                          "default": true
+                        },
+                        "text": {
+                          "type": "string",
+                          "title": "",
+                          "default": "Home",
+                          "_adapt": {
+                            "translatable": true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "_homeButton": {
           "type": "object",
           "title": "Home Button",

--- a/templates/HomeNavigationButton.jsx
+++ b/templates/HomeNavigationButton.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { classes, compile } from 'core/js/reactHelpers';
+
+export default function HomeNavigationButton(props) {
+  const {
+    text,
+    _iconClasses
+  } = props;
+  return (
+    <>
+      <span
+        className={classes([
+          'icon',
+          _iconClasses
+        ])}
+        aria-hidden="true"
+      />
+      <span
+        className="nav__btn-label"
+        aria-hidden="true"
+        dangerouslySetInnerHTML={{ __html: compile(text, props) }}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
Fixes #16 #23 

### Fix
* Adds support for Tooltip and Navigation Button APIs
* Allows overrides at the menu and content object level
* Creates JSX template for button contents

### Testing
Configure a course per _example.json_

To test overrides, add the config to a menu or content object. Then, simply use a non-empty value for the text that should be overridden (ex. `_homeButton.navLabel` or `_homeButton.alt`). In the AAT, these values should default to empty, so adding any text will override them.

### To do
* Finish updating schemas
* Update readme