### PR TITLE
Fix: Update schemas and documentation (fixes #25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ All configuration options must be added and amended, where appropriate, for all 
 
 ----------------------------
 
-**Framework versions:**  5+<br>
+**Framework versions:**  5.30.3+<br>
 **Author / maintainer:**  CGKineo<br>
 **Accessibility support:** WAI AA<br>
 **RTL support:** Yes<br>

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 ## Settings Overview
 
-**Home Button** can be configured based on the specific location where it is used (ex. a menu or a page). Options include:
+**Home Button** can be configured based on the specific location where it is used (e.g. a menu or a page). Options include:
 - Hiding either the home and/or back button. One or both can appear in the navigation at the same time.
 - Changing the text of the buttons
-- Redirecting the button to a specific location (ex. an introductory page)
+- Redirecting the button to a specific location (e.g. an introductory page)
 
 ## Attributes
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ The order that the button appears in the navigation
 #### **_showLabel** (boolean):
 Controls whether the button should use a navigation label or just an icon
 
+#### **alt** (string):
+The button's `aria-label` text. Used to override global setting
+
 #### **navLabel** (string):
 The button label text as it appears in the navigation
 
@@ -63,6 +66,9 @@ Controls whether the back button is hidden or not
 
 #### **\_redirectToId** (string):
 The page ID that the home button should redirect the user to. Use when overriding standard behaviour such as redirecting to an introductory page from the menu.
+
+#### **alt** (string):
+The button's `aria-label` text. Used to override global setting
 
 #### **navLabel** (string):
 The button label text as it appears in the navigation. Used to override global setting

--- a/README.md
+++ b/README.md
@@ -1,40 +1,79 @@
 # adapt-homeButton
 
-Add home button to course navigation. Allows hide or redirect of home button. Allows hide of back button.
+**Home Button** is an extension that adds more control to the standard home and back buttons. The home button can redirect to a specific location such as an introductory page. Both the home and back buttons can also be hidden on specific pages or on the menu.
 
 ## Settings
 
-All configuration options must be added and amended, where appropriate, for all json files.
+All configuration options must be added and amended, where appropriate, for all JSON files.
 
-#### Config
+## Attributes
 
-**\_homeButton** (object): The config.json Home Button target attribute object.
+### *config.json*
+The following attributes are set within *config.json*.
 
->**\_isEnabled** (boolean): Controls whether the Home Button extension is enabled or not.
+### **\_homeButton** (object):
+The Home Button object contains the following settings:
 
-#### Course
+#### **\_isEnabled** (boolean):
+Controls whether the Home Button extension is enabled
 
-**\_homeButton** (object): The course.json Home Button target attribute object.
+### *course.json*
+The following attributes are set within *course.json*. These are used to set the global settings and navigation order:
 
->**\_isEnabled** (boolean): Controls whether the Home Button course object is enabled or not.
+### **\_homeButton** (object):
+The Home Button object contains the following settings:
 
->**\_hideHomeButton** (boolean): Controls whether the navigational home button is hidden or not.
+#### **_navOrder** (number):
+The order that the button appears in the navigation
 
->**\_redirectToId** (string): Define the page ID that the home button should direct the user to in case an override to the standard behaviour is required.
+#### **_showLabel** (boolean):
+Controls whether the button should use a navigation label or just an icon
 
->**alt** (string): This text becomes the global home buttons's aria label attribute.
+#### **navLabel** (string):
+The button label text as it appears in the navigation
 
-#### ContentObject
+#### **_navTooltip** (object):
+The Navigation Tooltip object contains the following settings:
 
-**\_homeButton** (object): The contentObject.json Home Button target attribute object.
+##### **\_isEnabled** (boolean):
+Controls whether the navigation tooltip is enabled
 
->**\_isEnabled** (boolean): Controls whether the Home Button contentObject object is enabled or not.
+##### **text** (string):
+The text of the tooltip. Used to override global setting
 
->**\_hideHomeButton** (boolean): Controls whether the navigational home button is hidden or not.
+### *course.json / contentObjects.json*
+The following attributes are set within *course.json* and/or *contentObjects.json*. These are used to *override* global settings and customize the button for a specific page or menu.
 
->**\_hideBackButton** (boolean): Controls whether the navigational back button is hidden or not.
+### **\_homeButton** (object):
+The Home Button object contains the following settings:
 
->**\_redirectToId** (string): Define the page ID that the home button should direct the user to in case an override to the standard behaviour is required.
+#### **\_isEnabled** (boolean):
+Controls whether the Home Button extension is enabled
+
+#### **\_hideHomeButton** (boolean):
+Controls whether the home button is hidden or not
+
+#### **\_hideBackButton** (boolean):
+Controls whether the back button is hidden or not
+
+#### **\_redirectToId** (string):
+The page ID that the home button should redirect the user to. Use when overriding standard behaviour such as redirecting to an introductory page from the menu.
+
+#### **navLabel** (string):
+The button label text as it appears in the navigation. Used to override global setting
+
+#### **_navTooltip** (object):
+The Navigation Tooltip object contains the following settings:
+
+##### **\_isEnabled** (boolean):
+Controls whether the navigation tooltip is enabled. Used to override global setting
+
+##### **text** (string):
+The text of the tooltip. Used to override global setting
+
+## Limitations
+
+No known limitations.
 
 ----------------------------
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # adapt-homeButton
 
-**Home Button** is an extension that adds more control to the standard home and back buttons. The home button can redirect to a specific location such as an introductory page. Both the home and back buttons can also be hidden on specific pages or on the menu.
+**Home Button** is an extension that adds more control to the standard home and back buttons.
 
-## Settings
+## Settings Overview
 
-All configuration options must be added and amended, where appropriate, for all JSON files.
+**Home Button** can be configured based on the specific location where it is used (ex. a menu or a page). Options include:
+- Hiding either the home and/or back button. One or both can appear in the navigation at the same time.
+- Changing the text of the buttons
+- Redirecting the button to a specific location (ex. an introductory page)
 
 ## Attributes
+
+All configuration options must be added and amended, where appropriate, for all JSON files.
 
 ### *config.json*
 The following attributes are set within *config.json*.
@@ -18,7 +23,7 @@ The Home Button object contains the following settings:
 Controls whether the Home Button extension is enabled
 
 ### *course.json*
-The following attributes are set within *course.json*. These are used to set the global settings and navigation order:
+The following attributes are set within *course.json*. These are used to set some default settings and the navigation order:
 
 ### **\_homeButton** (object):
 The Home Button object contains the following settings:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Controls whether the Home Button extension is enabled
 Controls whether the home button is hidden or not
 
 #### **\_hideBackButton** (boolean):
-Controls whether the back button is hidden or not
+Controls whether the back button is hidden or not. Applies to *contentObjects.json* only.
 
 #### **\_redirectToId** (string):
 The page ID that the home button should redirect the user to. Use when overriding standard behaviour such as redirecting to an introductory page from the menu.

--- a/example.json
+++ b/example.json
@@ -22,6 +22,7 @@
 "_homeButton": {
   "_isEnabled": true,
   "_hideHomeButton": false,
+  "_hideBackButton": true,
   "_comment": "Amend _redirectToId to match the ID of the start / landing page",
   "_redirectToId": "",
   "_comment": "Option to override navigation button label and tooltip",

--- a/example.json
+++ b/example.json
@@ -18,7 +18,21 @@
   }
 }
 
-// course.json or contentObjects - Use to configure at the menu or content object level
+// course.json - Use to configure at the menu level
+"_homeButton": {
+  "_isEnabled": true,
+  "_hideHomeButton": false,
+  "_comment": "Amend _redirectToId to match the ID of the start / landing page",
+  "_redirectToId": "",
+  "_comment": "Option to override navigation button label and tooltip",
+  "navLabel": "Introduction",
+  "_navTooltip": {
+    "_isEnabled": true,
+    "text": "Introduction"
+  }
+}
+
+// contentObjects.json - Use to configure at the content object level
 "_homeButton": {
   "_isEnabled": true,
   "_hideHomeButton": false,

--- a/js/adapt-homeButton.js
+++ b/js/adapt-homeButton.js
@@ -65,6 +65,7 @@ class HomeButton extends Backbone.Controller {
     const currentModelConfig = this.currentModelConfig;
     const {
       _navOrder = -1,
+      alt,
       _showLabel = true,
       navLabel = '',
       _navTooltip = {}
@@ -75,7 +76,7 @@ class HomeButton extends Backbone.Controller {
       _showLabel,
       _classes: 'btn-icon nav__btn nav__homebutton-btn',
       _role: 'link',
-      ariaLabel: navLabel,
+      ariaLabel: alt || navLabel,
       text: navLabel,
       _navTooltip,
       _event: currentModelConfig?._redirectToId ? 'redirectedHomeButton' : 'homeButton'

--- a/properties.schema
+++ b/properties.schema
@@ -161,7 +161,7 @@
                   "type": "boolean",
                   "required": false,
                   "default": false,
-                  "title": "Enable control of the home button at menu level",
+                  "title": "Enable control of the home button at page level",
                   "inputType": "Checkbox",
                   "validators": []
                 },

--- a/properties.schema
+++ b/properties.schema
@@ -62,7 +62,7 @@
                 "_isEnabled": {
                   "type": "boolean",
                   "required": false,
-                  "default": false,
+                  "default": true,
                   "title": "Enable control of the home button plugin",
                   "inputType": "Checkbox"
                 }

--- a/properties.schema
+++ b/properties.schema
@@ -107,7 +107,7 @@
                   "required": false,
                   "default": "",
                   "title": "Redirect the home button to id",
-                  "help": "Enter the Friendly id of the page that the home button should direct the user to (ex. a splash page)",
+                  "help": "Enter the Friendly id of the page that the home button should direct the user to (e.g. a splash page)",
                   "inputType": "Text",
                   "validators": []
                 },
@@ -187,7 +187,7 @@
                   "required": false,
                   "default": "",
                   "title": "Redirect the home button to id",
-                  "help": "Enter the Friendly id of the page that the home button should direct the user to (ex. a splash page)",
+                  "help": "Enter the Friendly id of the page that the home button should direct the user to (e.g. a splash page)",
                   "inputType": "Text",
                   "validators": []
                 },

--- a/properties.schema
+++ b/properties.schema
@@ -94,14 +94,6 @@
                   "inputType": "Checkbox",
                   "validators": []
                 },
-                "_hideBackButton": {
-                  "type": "boolean",
-                  "required": false,
-                  "default": true,
-                  "title": "Hide the back button",
-                  "inputType": "Checkbox",
-                  "validators": []
-                },
                 "_redirectToId": {
                   "type": "string",
                   "required": false,

--- a/properties.schema
+++ b/properties.schema
@@ -9,7 +9,7 @@
       "required": true,
       "title": "Navigation bar order",
       "help": "Determines the order in which the button is displayed in the navigation bar. Negative numbers (e.g. -100) are left-aligned. Positive numbers (e.g. 100) are right-aligned.",
-      "default": 0,
+      "default": -1,
       "inputType": "Text"
     },
     "_showLabel": {

--- a/properties.schema
+++ b/properties.schema
@@ -116,6 +116,7 @@
                   "required": false,
                   "default": "Home",
                   "title": "Home button alt text",
+                  "help": "Used for aria-label value",
                   "inputType": "Text",
                   "validators": [],
                   "translatable": true
@@ -195,6 +196,7 @@
                   "required": false,
                   "default": "Home",
                   "title": "Home button alt text",
+                  "help": "Used for aria-label value",
                   "inputType": "Text",
                   "validators": [],
                   "translatable": true

--- a/properties.schema
+++ b/properties.schema
@@ -162,7 +162,7 @@
                   "type": "boolean",
                   "required": false,
                   "default": true,
-                  "title": "Enable control of the home button at page level",
+                  "title": "Enable control of the home button on this page",
                   "inputType": "Checkbox",
                   "validators": []
                 },

--- a/properties.schema
+++ b/properties.schema
@@ -10,8 +10,7 @@
       "title": "Navigation bar order",
       "help": "Determines the order in which the button is displayed in the navigation bar. Negative numbers (e.g. -100) are left-aligned. Positive numbers (e.g. 100) are right-aligned.",
       "default": 0,
-      "inputType": "Text",
-      "validators": []
+      "inputType": "Text"
     },
     "_showLabel": {
       "type": "boolean",
@@ -19,7 +18,6 @@
       "default": true,
       "title": "Enable navigation bar button label",
       "inputType": "Checkbox",
-      "validators": [],
       "help": "Controls whether a label is shown on the navigation bar button."
     },
     "navLabel": {
@@ -28,7 +26,6 @@
       "default": "Home",
       "title": "Navigation bar button label",
       "inputType": "Text",
-      "validators": [],
       "translatable": true
     },
     "_navTooltip": {
@@ -67,8 +64,7 @@
                   "required": false,
                   "default": false,
                   "title": "Enable control of the home button plugin",
-                  "inputType": "Checkbox",
-                  "validators": []
+                  "inputType": "Checkbox"
                 }
               }
             }
@@ -98,6 +94,14 @@
                   "inputType": "Checkbox",
                   "validators": []
                 },
+                "_hideBackButton": {
+                  "type": "boolean",
+                  "required": false,
+                  "default": true,
+                  "title": "Hide the back button",
+                  "inputType": "Checkbox",
+                  "validators": []
+                },
                 "_redirectToId": {
                   "type": "string",
                   "required": false,
@@ -111,10 +115,35 @@
                   "type": "string",
                   "required": false,
                   "default": "Home",
-                  "title": "Home button alt text - applied globally",
+                  "title": "Home button alt text",
                   "inputType": "Text",
                   "validators": [],
                   "translatable": true
+                },
+                "navLabel": {
+                  "type": "string",
+                  "required": true,
+                  "default": "Home",
+                  "title": "Navigation bar button label",
+                  "inputType": "Text",
+                  "translatable": true
+                },
+                "_navTooltip": {
+                  "type": "object",
+                  "title": "Navigation tooltip",
+                  "properties": {
+                    "_isEnabled": {
+                      "type": "boolean",
+                      "title": "Enable tooltip for navigation button",
+                      "default": true
+                    },
+                    "text": {
+                      "type": "string",
+                      "title": "",
+                      "default": "Home",
+                      "translatable": true
+                    }
+                  }
                 }
               }
             }
@@ -132,7 +161,7 @@
                   "type": "boolean",
                   "required": false,
                   "default": false,
-                  "title": "Enable control of the home button at page level",
+                  "title": "Enable control of the home button at menu level",
                   "inputType": "Checkbox",
                   "validators": []
                 },
@@ -147,7 +176,7 @@
                 "_hideBackButton": {
                   "type": "boolean",
                   "required": false,
-                  "default": false,
+                  "default": true,
                   "title": "Hide the back button",
                   "inputType": "Checkbox",
                   "validators": []
@@ -157,21 +186,47 @@
                   "required": false,
                   "default": "",
                   "title": "Redirect the home button to id",
+                  "help": "Enter the Friendly id of the page that the home button should direct the user to (ex. a splash page)",
                   "inputType": "Text",
                   "validators": []
+                },
+                "alt": {
+                  "type": "string",
+                  "required": false,
+                  "default": "Home",
+                  "title": "Home button alt text",
+                  "inputType": "Text",
+                  "validators": [],
+                  "translatable": true
+                },
+                "navLabel": {
+                  "type": "string",
+                  "required": true,
+                  "default": "Home",
+                  "title": "Navigation bar button label",
+                  "inputType": "Text",
+                  "translatable": true
+                },
+                "_navTooltip": {
+                  "type": "object",
+                  "title": "Navigation tooltip",
+                  "properties": {
+                    "_isEnabled": {
+                      "type": "boolean",
+                      "title": "Enable tooltip for navigation button",
+                      "default": true
+                    },
+                    "text": {
+                      "type": "string",
+                      "title": "",
+                      "default": "Home",
+                      "translatable": true
+                    }
+                  }
                 }
               }
             }
           }
-        },
-        "article": {
-          "type": "object"
-        },
-        "block": {
-          "type": "object"
-        },
-        "component": {
-          "type": "object"
         }
       }
     }

--- a/properties.schema
+++ b/properties.schema
@@ -160,7 +160,7 @@
                 "_isEnabled": {
                   "type": "boolean",
                   "required": false,
-                  "default": false,
+                  "default": true,
                   "title": "Enable control of the home button at page level",
                   "inputType": "Checkbox",
                   "validators": []

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -16,7 +16,7 @@
             "_isEnabled": {
               "type": "boolean",
               "title": "Enable control of the home button globally",
-              "default": false
+              "default": true
             }
           }
         }

--- a/schema/contentobject.schema.json
+++ b/schema/contentobject.schema.json
@@ -15,24 +15,60 @@
           "properties": {
             "_isEnabled": {
               "type": "boolean",
-              "title": "Enable control of the home button on this page",
+              "title": "Enable control of the home button at menu level",
               "default": false
             },
             "_hideHomeButton": {
               "type": "boolean",
-              "title": "Hide the home button on this page",
+              "title": "Hide the home button on the menu",
               "default": false
             },
             "_hideBackButton": {
               "type": "boolean",
-              "title": "Hide the back button on this page",
-              "default": false
+              "title": "Hide the back button on the menu",
+              "default": true
             },
             "_redirectToId": {
               "type": "string",
               "title": "Redirect the home button to id",
               "description": "Enter the Friendly id of the page that the home button should direct the user to (ex. a splash page)",
               "default": ""
+            },
+            "alt": {
+              "type": "string",
+              "title": "Home button alt text",
+              "default": "Home",
+              "_adapt": {
+                "translatable": true
+              }
+            },
+            "navLabel": {
+              "type": "string",
+              "title": "Navigation bar button label",
+              "default": "Home",
+              "_adapt": {
+                "translatable": true
+              }
+            },
+            "_navTooltip": {
+              "type": "object",
+              "title": "Home Button",
+              "default": {},
+              "properties": {
+                "_isEnabled": {
+                  "type": "boolean",
+                  "title": "Enable control of the home button at menu level",
+                  "default": false
+                },
+                "text": {
+                  "type": "string",
+                  "title": "",
+                  "default": "Home",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                }
+              }
             }
           }
         }

--- a/schema/contentobject.schema.json
+++ b/schema/contentobject.schema.json
@@ -37,6 +37,7 @@
             "alt": {
               "type": "string",
               "title": "Home button alt text",
+              "description": "Used for aria-label value",
               "default": "Home",
               "_adapt": {
                 "translatable": true

--- a/schema/contentobject.schema.json
+++ b/schema/contentobject.schema.json
@@ -15,17 +15,17 @@
           "properties": {
             "_isEnabled": {
               "type": "boolean",
-              "title": "Enable control of the home button at menu level",
-              "default": false
+              "title": "Enable control of the home button on this page",
+              "default": true
             },
             "_hideHomeButton": {
               "type": "boolean",
-              "title": "Hide the home button on the menu",
+              "title": "Hide the home button",
               "default": false
             },
             "_hideBackButton": {
               "type": "boolean",
-              "title": "Hide the back button on the menu",
+              "title": "Hide the back button",
               "default": true
             },
             "_redirectToId": {

--- a/schema/contentobject.schema.json
+++ b/schema/contentobject.schema.json
@@ -52,12 +52,12 @@
             },
             "_navTooltip": {
               "type": "object",
-              "title": "Home Button",
+              "title": "Navigation tooltip",
               "default": {},
               "properties": {
                 "_isEnabled": {
                   "type": "boolean",
-                  "title": "Enable control of the home button at menu level",
+                  "title": "Enable tooltip for navigation button",
                   "default": false
                 },
                 "text": {

--- a/schema/contentobject.schema.json
+++ b/schema/contentobject.schema.json
@@ -31,7 +31,7 @@
             "_redirectToId": {
               "type": "string",
               "title": "Redirect the home button to id",
-              "description": "Enter the Friendly id of the page that the home button should direct the user to (ex. a splash page)",
+              "description": "Enter the Friendly id of the page that the home button should direct the user to (e.g. a splash page)",
               "default": ""
             },
             "alt": {

--- a/schema/contentobject.schema.json
+++ b/schema/contentobject.schema.json
@@ -59,7 +59,7 @@
                 "_isEnabled": {
                   "type": "boolean",
                   "title": "Enable tooltip for navigation button",
-                  "default": false
+                  "default": true
                 },
                 "text": {
                   "type": "string",

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -43,6 +43,7 @@
                     "_navTooltip": {
                       "type": "object",
                       "title": "Navigation tooltip",
+                      "default": {},
                       "properties": {
                         "_isEnabled": {
                           "type": "boolean",

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -80,11 +80,52 @@
               "title": "Hide the home button on the menu",
               "default": false
             },
+            "_hideBackButton": {
+              "type": "boolean",
+              "title": "Hide the back button on the menu",
+              "default": true
+            },
             "_redirectToId": {
               "type": "string",
               "title": "Redirect the home button to id",
               "description": "Enter the Friendly id of the page that the home button should direct the user to (ex. a splash page)",
               "default": ""
+            },
+            "alt": {
+              "type": "string",
+              "title": "Home button alt text",
+              "default": "Home",
+              "_adapt": {
+                "translatable": true
+              }
+            },
+            "navLabel": {
+              "type": "string",
+              "title": "Navigation bar button label",
+              "default": "Home",
+              "_adapt": {
+                "translatable": true
+              }
+            },
+            "_navTooltip": {
+              "type": "object",
+              "title": "Home Button",
+              "default": {},
+              "properties": {
+                "_isEnabled": {
+                  "type": "boolean",
+                  "title": "Enable control of the home button at menu level",
+                  "default": false
+                },
+                "text": {
+                  "type": "string",
+                  "title": "",
+                  "default": "Home",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                }
+              }
             }
           }
         }

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -81,11 +81,6 @@
               "title": "Hide the home button on the menu",
               "default": false
             },
-            "_hideBackButton": {
-              "type": "boolean",
-              "title": "Hide the back button on the menu",
-              "default": true
-            },
             "_redirectToId": {
               "type": "string",
               "title": "Redirect the home button to id",

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -89,7 +89,7 @@
             "_redirectToId": {
               "type": "string",
               "title": "Redirect the home button to id",
-              "description": "Enter the Friendly id of the page that the home button should direct the user to (ex. a splash page)",
+              "description": "Enter the Friendly id of the page that the home button should direct the user to (e.g. a splash page)",
               "default": ""
             },
             "alt": {

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -117,7 +117,7 @@
                 "_isEnabled": {
                   "type": "boolean",
                   "title": "Enable tooltip for navigation button",
-                  "default": false
+                  "default": true
                 },
                 "text": {
                   "type": "string",

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -95,6 +95,7 @@
             "alt": {
               "type": "string",
               "title": "Home button alt text",
+              "description": "Used for aria-label value",
               "default": "Home",
               "_adapt": {
                 "translatable": true

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -109,12 +109,12 @@
             },
             "_navTooltip": {
               "type": "object",
-              "title": "Home Button",
+              "title": "Navigation tooltip",
               "default": {},
               "properties": {
                 "_isEnabled": {
                   "type": "boolean",
-                  "title": "Enable control of the home button at menu level",
+                  "title": "Enable tooltip for navigation button",
                   "default": false
                 },
                 "text": {


### PR DESCRIPTION
Fixes #25 

### Fix
* Update `README.md` with new properties
* Update `README.md` to reflect required framework version
* Update `properties.schema`
* Update newer schemas in `/schema`
* Update `example.json` with missing properties
* Fix `alt` property not being used. Will now use `alt` for the `aria-label` and will fallback to `navLabel` if not set.