### PR TITLE
New: Add _isInherited option to inherit course defaults (fixes #36)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 * A sentence describing each fix
 
 ### Update
-* A sentence describing each udpate
+* A sentence describing each update
 
 ### New
 * A sentence describing each new feature

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The following attributes are set within *course.json*. These are used to set som
 
 #### *course.json* and *contentObjects.json*
 
-The following attributes are set within *course.json* and / or *contentObjects.json*. These are used to customize the button for a specific page or menu.
+The following attributes are set within *course.json* and / or *contentObjects.json*. These are used to customize the button for a specific menu or page.
 
 **\_homeButton** (object): The Home Button object contains the following settings:
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ The following attributes are set within *course.json* and / or *contentObjects.j
 
 >**\_isEnabled** (boolean): Controls whether the Home Button extension is enabled.
 
+>**\_isInherited** (boolean): Controls whether to use the course defaults defined in *course.json* under `_extensions._homeButton`. If disabled, the current content object's settings will be used in place of the course defaults. Properties inherited include `alt`, `navLabel`, and `_navTooltip`. Defaults to `true`.
+
 >**\_hideHomeButton** (boolean): Controls whether the home button is hidden or not.
 
 >**\_hideBackButton** (boolean): Controls whether the back button is hidden or not. Applies to *contentObjects.json* only.
@@ -67,14 +69,6 @@ The following attributes are set within *course.json* and / or *contentObjects.j
 >>**\_isEnabled** (boolean): Controls whether the navigation tooltip is enabled. Used to override global setting.
 
 >>**text** (string): The text of the tooltip. Used to override global setting.
-
-#### *contentObjects.json*
-
-The following additional attributes are set within *contentObjects.json*.
-
-**\_homeButton** (object): The Home Button object contains the following additional settings:
-
->**\_isInherited** (boolean): Controls whether to use the course defaults defined in *course.json* under `_extensions._homeButton`. If disabled, the current content object's settings will be used in place of the course defaults. Properties inherited include `alt`, `navLabel`, and `_navTooltip`. Defaults to `true`.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following attributes are set within *config.json*.
 
 #### *course.json*
 
-The following attributes are set within *course.json*. These are used to set some default and global settings.
+The following attributes are set within *course.json* under `_extensions`. These are used to set some default and global settings.
 
 **\_homeButton** (object): The Home Button object contains the following settings:
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ The following attributes are set within *course.json* and / or *contentObjects.j
 
 >**\_isEnabled** (boolean): Controls whether the Home Button extension is enabled.
 
+>**\_isInherited** (boolean): Controls whether to use the course defaults defined in *course.json* under `_extensions._homeButton`. If disabled, these settings will override the course defaults. Defaults to `true`.
+
 >**\_hideHomeButton** (boolean): Controls whether the home button is hidden or not.
 
 >**\_hideBackButton** (boolean): Controls whether the back button is hidden or not. Applies to *contentObjects.json* only.
@@ -73,8 +75,7 @@ No known limitations.
 
 ----------------------------
 
-**Framework versions:** 5.30.3+<br>
 **Author / maintainer:** CGKineo<br>
 **Accessibility support:** WAI AA<br>
 **RTL support:** Yes<br>
-**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 12+13 for macOS/iOS/iPadOS, Opera<br>
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, Safari for macOS/iOS/iPadOS, Opera<br>

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ## Settings Overview
 
 **Home Button** can be configured based on the specific location where it is used (e.g. a menu or a page). Options include:
+
 - Hiding either the home and/or back button. One or both can appear in the navigation at the same time.
 - Changing the text of the buttons
 - Redirecting the button to a specific location (e.g. an introductory page)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The following attributes are set within *course.json* and / or *contentObjects.j
 
 >**\_isEnabled** (boolean): Controls whether the Home Button extension is enabled.
 
->**\_isInherited** (boolean): Controls whether to use the course defaults defined in *course.json* under `_extensions._homeButton`. If disabled, these settings will override the course defaults. Defaults to `true`.
+>**\_isInherited** (boolean): Controls whether to use the course defaults defined in *course.json* under `_extensions._homeButton`. If disabled, the current model's settings will be used in place of the course defaults. Properties inherited include `alt`, `navLabel`, and `_navTooltip`. Defaults to `true`.
 
 >**\_hideHomeButton** (boolean): Controls whether the home button is hidden or not.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The following attributes are set within *config.json*.
 
 The following attributes are set within *course.json* under `_extensions`. These are used to set some default and global settings.
 
-**\_homeButton** (object): The Home Button object contains the following settings:
+**\_extensions._homeButton** (object): The Home Button object contains the following settings:
 
 >**\_navOrder** (number): The order that the button appears in the navigation.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 All configuration options must be added and amended, where appropriate, for all JSON files.
 
-*config.json*
+#### *config.json*
 
 The following attributes are set within *config.json*.
 
@@ -22,9 +22,9 @@ The following attributes are set within *config.json*.
 
 >**\_isEnabled** (boolean): Controls whether the Home Button extension is enabled.
 
-*course.json*
+#### *course.json*
 
-The following attributes are set within *course.json*. These are used to set some default settings and the navigation order:
+The following attributes are set within *course.json*. These are used to set some default and global settings.
 
 **\_homeButton** (object): The Home Button object contains the following settings:
 
@@ -42,15 +42,13 @@ The following attributes are set within *course.json*. These are used to set som
 
 >>**text** (string): The text of the tooltip. Used to override global setting.
 
-*course.json* and *contentObjects.json*
+#### *course.json* and *contentObjects.json*
 
-The following attributes are set within *course.json* and / or *contentObjects.json*. These are used to *override* global settings and customize the button for a specific page or menu.
+The following attributes are set within *course.json* and / or *contentObjects.json*. These are used to customize the button for a specific page or menu.
 
 **\_homeButton** (object): The Home Button object contains the following settings:
 
 >**\_isEnabled** (boolean): Controls whether the Home Button extension is enabled.
-
->**\_isInherited** (boolean): Controls whether to use the course defaults defined in *course.json* under `_extensions._homeButton`. If disabled, the current model's settings will be used in place of the course defaults. Properties inherited include `alt`, `navLabel`, and `_navTooltip`. Defaults to `true`.
 
 >**\_hideHomeButton** (boolean): Controls whether the home button is hidden or not.
 
@@ -69,6 +67,14 @@ The following attributes are set within *course.json* and / or *contentObjects.j
 >>**\_isEnabled** (boolean): Controls whether the navigation tooltip is enabled. Used to override global setting.
 
 >>**text** (string): The text of the tooltip. Used to override global setting.
+
+#### *contentObjects.json*
+
+The following additional attributes are set within *contentObjects.json*.
+
+**\_homeButton** (object): The Home Button object contains the following additional settings:
+
+>**\_isInherited** (boolean): Controls whether to use the course defaults defined in *course.json* under `_extensions._homeButton`. If disabled, the current content object's settings will be used in place of the course defaults. Properties inherited include `alt`, `navLabel`, and `_navTooltip`. Defaults to `true`.
 
 ## Limitations
 

--- a/example.json
+++ b/example.json
@@ -22,6 +22,7 @@
 // course.json - Use to configure at the menu level
 "_homeButton": {
   "_isEnabled": true,
+  "_isInherited": true,
   "_hideHomeButton": false,
   "_comment": "Amend _redirectToId to match the ID of the start / landing page",
   "_redirectToId": "",
@@ -38,6 +39,7 @@
 // contentObjects.json - Use to configure at the content object level
 "_homeButton": {
   "_isEnabled": true,
+  "_isInherited": true,
   "_hideHomeButton": false,
   "_hideBackButton": true,
   "_comment": "Amend _redirectToId to match the ID of the start / landing page",

--- a/example.json
+++ b/example.json
@@ -22,6 +22,7 @@
 // course.json - Use to configure at the menu level
 "_homeButton": {
   "_isEnabled": true,
+  "_isInherited": true,
   "_hideHomeButton": false,
   "_comment": "Amend _redirectToId to match the ID of the start / landing page",
   "_redirectToId": "",

--- a/example.json
+++ b/example.json
@@ -22,7 +22,6 @@
 // course.json - Use to configure at the menu level
 "_homeButton": {
   "_isEnabled": true,
-  "_isInherited": true,
   "_hideHomeButton": false,
   "_comment": "Amend _redirectToId to match the ID of the start / landing page",
   "_redirectToId": "",

--- a/js/adapt-homeButton.js
+++ b/js/adapt-homeButton.js
@@ -72,7 +72,7 @@ class HomeButton extends Backbone.Controller {
 
   renderNavigationView() {
     const currentModelConfig = this.currentModelConfig;
-    const isInherited = currentModelConfig._isInherited && true;
+    const isInherited = currentModelConfig._isInherited ?? true;
     const modelConfig = isInherited ? (HomeButton.globalsConfig ?? {}) : currentModelConfig;
     const {
       _navOrder = -1,

--- a/js/adapt-homeButton.js
+++ b/js/adapt-homeButton.js
@@ -72,13 +72,15 @@ class HomeButton extends Backbone.Controller {
 
   renderNavigationView() {
     const currentModelConfig = this.currentModelConfig;
+    const isInherited = currentModelConfig._isInherited && true;
+    const modelConfig = isInherited ? (HomeButton.globalsConfig ?? {}) : currentModelConfig;
     const {
       _navOrder = -1,
       alt,
       _showLabel = true,
       navLabel = '',
       _navTooltip = {}
-    } = Object.assign(HomeButton.globalsConfig ?? {}, currentModelConfig);
+    } = modelConfig;
     const model = new NavigationButtonModel({
       _id: 'homebutton',
       _order: _navOrder,

--- a/js/adapt-homeButton.js
+++ b/js/adapt-homeButton.js
@@ -39,6 +39,15 @@ class HomeButton extends Backbone.Controller {
     return Adapt.course?.get('_homeButton');
   }
 
+  get iconClasses() {
+    const currentIconClass = this.currentModelConfig._iconClasses;
+    const courseIconClass = this.courseConfig?._iconClasses;
+    const currentLocation = location._currentLocation;
+    const defaultClass = (currentLocation !== 'course') ? 'icon-home' : 'icon-controls-small-left';
+
+    return (currentIconClass || courseIconClass || defaultClass);
+  }
+
   onRouterEvent() {
     const isEnabled = (this.currentModelConfig?._isEnabled);
     if (!isEnabled) return this.disable();
@@ -65,7 +74,6 @@ class HomeButton extends Backbone.Controller {
     const currentModelConfig = this.currentModelConfig;
     const {
       _navOrder = -1,
-      _iconClasses,
       alt,
       _showLabel = true,
       navLabel = '',
@@ -77,7 +85,7 @@ class HomeButton extends Backbone.Controller {
       _showLabel,
       _classes: 'btn-icon nav__btn nav__homebutton-btn',
       courseConfig: HomeButton.courseConfig,
-      _iconClasses,
+      _iconClasses: this.iconClasses,
       _role: 'link',
       ariaLabel: alt || navLabel,
       text: navLabel,

--- a/properties.schema
+++ b/properties.schema
@@ -91,6 +91,13 @@
                   "inputType": "Checkbox",
                   "validators": []
                 },
+                "_isInherited": {
+                  "type": "boolean",
+                  "default": true,
+                  "title": "Use course defaults",
+                  "inputType": "Checkbox",
+                  "help": "If disabled, these settings will override the course defaults"
+                },
                 "_hideHomeButton": {
                   "type": "boolean",
                   "required": false,
@@ -165,6 +172,13 @@
                   "title": "Enable control of the home button on this page",
                   "inputType": "Checkbox",
                   "validators": []
+                },
+                "_isInherited": {
+                  "type": "boolean",
+                  "default": true,
+                  "title": "Use course defaults",
+                  "inputType": "Checkbox",
+                  "help": "If disabled, these settings will override the course defaults"
                 },
                 "_hideHomeButton": {
                   "type": "boolean",

--- a/properties.schema
+++ b/properties.schema
@@ -91,13 +91,6 @@
                   "inputType": "Checkbox",
                   "validators": []
                 },
-                "_isInherited": {
-                  "type": "boolean",
-                  "default": true,
-                  "title": "Use course defaults",
-                  "inputType": "Checkbox",
-                  "help": "If disabled, these settings will override the course defaults"
-                },
                 "_hideHomeButton": {
                   "type": "boolean",
                   "required": false,

--- a/properties.schema
+++ b/properties.schema
@@ -91,6 +91,13 @@
                   "inputType": "Checkbox",
                   "validators": []
                 },
+                "_isInherited": {
+                  "type": "boolean",
+                  "default": true,
+                  "title": "Use course defaults",
+                  "inputType": "Checkbox",
+                  "help": "If disabled, these settings will override the course defaults"
+                },
                 "_hideHomeButton": {
                   "type": "boolean",
                   "required": false,

--- a/schema/contentobject.schema.json
+++ b/schema/contentobject.schema.json
@@ -18,6 +18,12 @@
               "title": "Enable control of the home button on this page",
               "default": true
             },
+            "_isInherited": {
+              "type": "boolean",
+              "title": "Use course defaults",
+              "default": true,
+              "description": "If disabled, these settings will override the course defaults"
+            },
             "_hideHomeButton": {
               "type": "boolean",
               "title": "Hide the home button",

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -76,6 +76,12 @@
               "title": "Enable control of the home button at menu level",
               "default": false
             },
+            "_isInherited": {
+              "type": "boolean",
+              "title": "Use course defaults",
+              "default": true,
+              "description": "If disabled, these settings will override the course defaults"
+            },
             "_hideHomeButton": {
               "type": "boolean",
               "title": "Hide the home button on the menu",

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -76,12 +76,6 @@
               "title": "Enable control of the home button at menu level",
               "default": false
             },
-            "_isInherited": {
-              "type": "boolean",
-              "title": "Use course defaults",
-              "default": true,
-              "description": "If disabled, these settings will override the course defaults"
-            },
             "_hideHomeButton": {
               "type": "boolean",
               "title": "Hide the home button on the menu",

--- a/templates/HomeNavigationButton.jsx
+++ b/templates/HomeNavigationButton.jsx
@@ -1,27 +1,18 @@
 import React from 'react';
-import location from 'core/js/location';
 import { classes, compile } from 'core/js/reactHelpers';
 
 export default function HomeNavigationButton(props) {
   const {
     text,
-    _iconClasses,
-    courseConfig
+    _iconClasses
   } = props;
-
-  const currentIconClass = _iconClasses;
-  const courseIconClass = courseConfig?._iconClasses;
-  const currentLocation = location._currentLocation;
-  const defaultClass = (currentLocation !== 'course') ? 'icon-home' : 'icon-controls-small-left';
-
-  const iconClass = (currentIconClass || courseIconClass || defaultClass);
 
   return (
     <>
       <span
         className={classes([
           'icon',
-          iconClass
+          _iconClasses
         ])}
         aria-hidden="true"
       />


### PR DESCRIPTION
Fix #36 

### New
* Adds `_isInherited` option to inherit course defaults defined in `_extensions._homeButton` in _course.json_.
* Can by used in _course.json_ and _contentObjects.json_
* Inherited properties include `alt`, `navLabel`, and `_navTooltip`

### Update
* Moves icon classes logic out of template and into the JS.
